### PR TITLE
get previous data in the task code

### DIFF
--- a/Simulator/engine/components.h
+++ b/Simulator/engine/components.h
@@ -269,7 +269,7 @@ public:
 	vector<Task*> predecessors;		// job level predecessor
 	vector<Task*> successors;		// job level successor
 
-	virtual void procedure() = 0;
+	virtual float procedure(float previous_data) = 0;
 	virtual void write() = 0;
 
 	int get_job_id();

--- a/Simulator/engine/real-time_simulator_basic.cpp
+++ b/Simulator/engine/real-time_simulator_basic.cpp
@@ -21,6 +21,8 @@ timeval now;				// real time
 // for internal data
 float memory_buffer[10];
 float user_input_internal[10];
+float previous_data[10];
+enum previous_data{CC1, CC2, LK1, LK2, LK3};
 
 // for sending data
 list<CAN_Msg *> waiting_data;
@@ -188,7 +190,18 @@ int main(int argc, char* argv[])
 				current_time_temp += next->task_link->get_modified_wcet();
 
 			// execute a task (job)
-			next->procedure();
+			if(strcmp("CC1", task_name) == 0)
+				previous_data[CC1] = next->procedure(previous_data[CC1]);
+			else if(strcmp("CC2", task_name) == 0)
+				previous_data[CC2] = next->procedure(previous_data[CC2]);
+			else if(strcmp("LK1", task_name) == 0)
+				previous_data[LK1] = next->procedure(previous_data[LK1]);
+			else if(strcmp("LK2", task_name) == 0)
+				previous_data[LK2] = next->procedure(previous_data[LK2]);
+			else if(strcmp("LK3", task_name) == 0)
+				previous_data[LK3] = next->procedure(previous_data[LK3]);
+			else	
+				next->procedure(0);
 			next->write();
 
 			// print seriaized schedule

--- a/Simulator/parser/DesignParser.cpp
+++ b/Simulator/parser/DesignParser.cpp
@@ -207,7 +207,7 @@ void DesignParser::generateTaskCode()
 		fprintf(ofp_task_created_h, "public:\n");		// public
 		fprintf(ofp_task_created_h, "\tTask%d();\n\tTask%d(Task_info*);\n\t~Task%d();\n\n",
 			t_id, t_id, t_id);
-		fprintf(ofp_task_created_h, "\tvirtual void procedure();\n\tvirtual void write();\n};\n\n");
+		fprintf(ofp_task_created_h, "\tvirtual float procedure(float previous_data);\n\tvirtual void write();\n};\n\n");
 
 		/*********************/
 		// for task_created.cpp
@@ -335,7 +335,7 @@ void DesignParser::generateTaskCode()
 			fgets(line_temp, 1000, ifp);
 
 		// for procedure() function
-		fprintf(ofp_task_created_c, "void Task%d::procedure()\n", t_id);
+		fprintf(ofp_task_created_c, "float Task%d::procedure(float previous_data)\n", t_id);
 		while(fgets(line_temp, 1000, ifp) != NULL)
 		{
 			fprintf(ofp_task_created_c, "%s", line_temp);


### PR DESCRIPTION
This PR changes `components.h, DesignParser.cpp, real-time_simulator_basic.cpp` to apply a new feature which allows using previous data in task codes of eclipse.

Usage: On each task codes such as `CC1.h`, return a value that you want to use in the next execution of the task code such as `code:` in `CC1.h`. Then, it will be stored in `real-time_simulator` and passed to the procedure of the task by a parameter previous_data. Thus, you can access it by previous_data in task codes.

Example:
```
var:0

input:0

output:1
internal_data[4]

CAN_input:1
0:0x7FD:1
car_output[SPEED]

CAN_output:0

code:
{
	float want_to_store;
	float data = previous_data;		//you can access stored data (want_to_store from previous execution) by previous_data

	internal_data[4] = car_output[SPEED];

	return want_to_store;		//return what you want to store globally
}
```